### PR TITLE
fix: stop a nil telemetry measurement from killing the application tree

### DIFF
--- a/lib/wanderer_kills/core/ets_owner.ex
+++ b/lib/wanderer_kills/core/ets_owner.ex
@@ -9,6 +9,8 @@ defmodule WandererKills.Core.EtsOwner do
   use GenServer
   require Logger
 
+  alias WandererKills.Subs.{CharacterIndex, SystemIndex}
+
   @websocket_stats_table :websocket_stats
   @wanderer_kills_stats_table :wanderer_kills_stats
 
@@ -113,7 +115,23 @@ defmodule WandererKills.Core.EtsOwner do
 
     Logger.info("ETS tables initialized successfully")
 
-    {:ok, %{tables: [@websocket_stats_table, @wanderer_kills_stats_table]}}
+    # The subscription indexes are plain named ETS tables created by whichever
+    # process calls init/0 first. Creating them here binds them to this
+    # long-lived process instead: without it the first caller can be an
+    # ephemeral one (an ExUnit test process, say), and the table vanishes with
+    # it, leaving every later reader with a dead table identifier.
+    CharacterIndex.init()
+    SystemIndex.init()
+
+    {:ok,
+     %{
+       tables: [
+         @websocket_stats_table,
+         @wanderer_kills_stats_table,
+         CharacterIndex.table_name(),
+         SystemIndex.table_name()
+       ]
+     }}
   end
 
   @doc """

--- a/lib/wanderer_kills/core/observability/telemetry.ex
+++ b/lib/wanderer_kills/core/observability/telemetry.ex
@@ -484,8 +484,20 @@ defmodule WandererKills.Core.Observability.Telemetry do
   end
 
   @impl true
-  def handle_cast({:increment, key, value}, state) do
+  def handle_cast({:increment, key, value}, state) when is_number(value) do
     :ets.update_counter(@table, key, value, {key, 0})
+    {:noreply, state}
+  end
+
+  # Metrics collection must never take the server down: an unusable increment
+  # from one instrumented call site would otherwise crash-loop this GenServer
+  # and, past the supervisor's restart intensity, the whole application tree.
+  def handle_cast({:increment, key, value}, state) do
+    Logger.warning("Ignoring non-numeric telemetry counter increment",
+      key: key,
+      value: inspect(value)
+    )
+
     {:noreply, state}
   end
 
@@ -683,8 +695,14 @@ defmodule WandererKills.Core.Observability.Telemetry do
         status_code = metadata[:status_code]
         tokens_consumed = measurements[:tokens_consumed]
 
-        # Track tokens consumed by service and status code
-        increment_counter("rate_limiter_#{service}_tokens_consumed", tokens_consumed)
+        # Track tokens consumed by service and status code.
+        # Not every :token_consumed emitter reports a consumed amount -- the
+        # reserved-token path only carries :tokens_remaining -- so skip the
+        # counter rather than passing nil to :ets.update_counter/4.
+        if tokens_consumed do
+          increment_counter("rate_limiter_#{service}_tokens_consumed", tokens_consumed)
+        end
+
         increment_counter("rate_limiter_#{service}_#{status_code}_requests")
 
         # Update remaining tokens gauge

--- a/lib/wanderer_kills/subs/character_index.ex
+++ b/lib/wanderer_kills/subs/character_index.ex
@@ -12,6 +12,10 @@ defmodule WandererKills.Subs.CharacterIndex do
   # Public API
   # ============================================================================
 
+  @doc "Name of the ETS table backing this index"
+  @spec table_name() :: atom()
+  def table_name, do: @table_name
+
   @doc "Initialize the ETS table"
   @spec init() :: :ok
   def init do

--- a/lib/wanderer_kills/subs/system_index.ex
+++ b/lib/wanderer_kills/subs/system_index.ex
@@ -12,6 +12,10 @@ defmodule WandererKills.Subs.SystemIndex do
   # Public API
   # ============================================================================
 
+  @doc "Name of the ETS table backing this index"
+  @spec table_name() :: atom()
+  def table_name, do: @table_name
+
   @doc "Initialize the ETS table"
   @spec init() :: :ok
   def init do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -495,14 +495,27 @@ defmodule WandererKills.TestHelpers do
   # ============================================================================
 
   @doc """
-  Ensures the TaskSupervisor is running, starting it if needed.
+  Ensures the TaskSupervisor is running, waiting for it if it is mid-restart.
   This helper is useful in tests that require the WandererKills.TaskSupervisor.
+
+  The TaskSupervisor is an application-level singleton owned by
+  `WandererKills.Application`. It is deliberately *not* started under the ExUnit
+  test supervisor here: doing so hands a globally-registered name to a
+  supervisor that tears it down at the end of the current test, so every later
+  test in the run finds it gone. If it is briefly absent it is being restarted
+  by the application supervisor, so wait for that instead.
   """
   def ensure_task_supervisor do
     case Process.whereis(WandererKills.TaskSupervisor) do
       nil ->
-        ExUnit.Callbacks.start_supervised!({Task.Supervisor, name: WandererKills.TaskSupervisor})
-        :ok
+        case wait_for_process(WandererKills.TaskSupervisor) do
+          {:ok, _pid} ->
+            :ok
+
+          {:error, :timeout} ->
+            raise "WandererKills.TaskSupervisor is not running and did not restart. " <>
+                    "Is the :wanderer_kills application started?"
+        end
 
       _pid ->
         :ok
@@ -514,28 +527,21 @@ defmodule WandererKills.TestHelpers do
   """
   def wait_for_process(name, timeout \\ 1000) do
     deadline = System.monotonic_time(:millisecond) + timeout
+    do_wait_for_process(name, deadline)
+  end
 
-    Stream.repeatedly(fn ->
-      case Process.whereis(name) do
-        nil ->
+  defp do_wait_for_process(name, deadline) do
+    case Process.whereis(name) do
+      nil ->
+        if System.monotonic_time(:millisecond) < deadline do
           Process.sleep(10)
-          :retry
+          do_wait_for_process(name, deadline)
+        else
+          {:error, :timeout}
+        end
 
-        pid ->
-          {:ok, pid}
-      end
-    end)
-    |> Stream.take_while(fn
-      :retry -> System.monotonic_time(:millisecond) < deadline
-      _ -> false
-    end)
-    |> Enum.reduce(:retry, fn
-      {:ok, pid}, _ -> {:ok, pid}
-      :retry, _ -> :retry
-    end)
-    |> case do
-      {:ok, pid} -> {:ok, pid}
-      :retry -> {:error, :timeout}
+      pid ->
+        {:ok, pid}
     end
   end
 

--- a/test/wanderer_kills/character_subscription_integration_test.exs
+++ b/test/wanderer_kills/character_subscription_integration_test.exs
@@ -13,17 +13,15 @@ defmodule WandererKills.CharacterSubscriptionIntegrationTest do
   alias WandererKills.Subs.{CharacterIndex, SystemIndex}
 
   setup do
-    # Ensure TaskSupervisor is started
-    case Process.whereis(WandererKills.TaskSupervisor) do
-      nil -> start_supervised!({Task.Supervisor, name: WandererKills.TaskSupervisor})
-      _pid -> :ok
-    end
+    # Both the TaskSupervisor and the SimpleSubscriptionManager are
+    # application-level singletons. Starting a replacement under the ExUnit test
+    # supervisor would tear it down at the end of this test and strand every
+    # later test in the run -- and the manager owns the subscription index ETS
+    # tables, which would go with it. Wait for the application supervisor
+    # instead.
+    WandererKills.TestHelpers.ensure_task_supervisor()
 
-    # Ensure SimpleSubscriptionManager is started
-    case Process.whereis(SubscriptionManager) do
-      nil -> start_supervised!(SubscriptionManager)
-      _pid -> :ok
-    end
+    {:ok, _pid} = WandererKills.TestHelpers.wait_for_process(SubscriptionManager)
 
     # Clear any existing subscriptions
     SubscriptionManager.clear_all_subscriptions()

--- a/test/wanderer_kills/ingest/historical/historical_streamer_test.exs
+++ b/test/wanderer_kills/ingest/historical/historical_streamer_test.exs
@@ -18,14 +18,7 @@ defmodule WandererKills.Ingest.Historical.HistoricalStreamerTest do
     end
 
     # Double-check TaskSupervisor is available
-    case Process.whereis(WandererKills.TaskSupervisor) do
-      nil ->
-        # If it's still not running, start it under the test supervisor
-        start_supervised!({Task.Supervisor, name: WandererKills.TaskSupervisor})
-
-      _pid ->
-        :ok
-    end
+    ensure_task_supervisor()
 
     # Mock configuration for testing
     test_config = %{

--- a/test/wanderer_kills/observability/telemetry_metrics_test.exs
+++ b/test/wanderer_kills/observability/telemetry_metrics_test.exs
@@ -223,4 +223,36 @@ defmodule WandererKills.Core.Observability.TelemetryMetricsTest do
       assert metrics[:tasks_failed] == 0
     end
   end
+
+  describe "counter robustness" do
+    test "survives an increment carrying no numeric amount" do
+      pid = Process.whereis(Telemetry)
+
+      # A :token_consumed event emitted without a :tokens_consumed measurement
+      # used to reach :ets.update_counter/4 with nil and crash this GenServer.
+      # Repeated crashes exhausted the application supervisor's restart
+      # intensity and took the whole tree down mid-suite.
+      Telemetry.increment_counter("counter_with_nil_amount", nil)
+
+      :sys.get_state(Telemetry)
+
+      assert Process.alive?(pid)
+      assert Process.whereis(Telemetry) == pid
+    end
+
+    test "a rate limiter token_consumed event without a consumed amount is survivable" do
+      pid = Process.whereis(Telemetry)
+
+      :telemetry.execute(
+        [:wanderer_kills, :rate_limiter, :token_consumed],
+        %{tokens_remaining: 5},
+        %{service: "zkillboard", status_code: 200}
+      )
+
+      :sys.get_state(Telemetry)
+
+      assert Process.alive?(pid)
+      assert Process.whereis(Telemetry) == pid
+    end
+  end
 end


### PR DESCRIPTION
## Why

The test suite passes or fails depending on ExUnit's random seed. On CI this showed up as three failures in `CharacterSubscriptionIntegrationTest`, all in `setup`:

```
** (ArgumentError) the table identifier does not refer to an existing ETS table
   :ets.internal_delete_all(:character_subscription_index, :undefined)
   lib/wanderer_kills/subs/character_index.ex:76: CharacterIndex.clear/0
```

The same job ran the suite twice on identical code — `mix test` reported 0 failures, `mix test.coverage.ci` reported 3 — which pointed at ordering rather than anything in the diff under test.

## Root cause

`SmartRateLimiter` emits `[:wanderer_kills, :rate_limiter, :token_consumed]` from two places. The reserved-token path (`smart_rate_limiter.ex:726`) carries only `:tokens_remaining`:

```elixir
:telemetry.execute(
  [:wanderer_kills, :rate_limiter, :token_consumed],
  %{tokens_remaining: updated_bucket.tokens},
  %{service: service}
)
```

The metrics handler read `measurements[:tokens_consumed]` unconditionally, so that path reached `:ets.update_counter/4` with `nil`:

```
** (ArgumentError) 3rd argument: not a valid update operation
   :ets.update_counter(:telemetry_metrics, "rate_limiter_zkillboard_tokens_consumed", nil, ...)
   lib/wanderer_kills/core/observability/telemetry.ex:488
```

The `Telemetry` GenServer crashed, the supervisor restarted it, it crashed again — and once the restarts exceeded `WandererKills.Supervisor`'s restart intensity, **the entire application supervision tree shut down**. Everything the tree owned went with it: the `TaskSupervisor`, and the subscription index ETS tables owned by `SimpleSubscriptionManager`. Whichever test ran next failed on whichever piece it touched first, which is why the reported failure moved around with the seed and never named the actual culprit.

This is a production bug, not just a test one. Any sustained burst of reserved-token consumption can take the node down.

## What changed

Outermost cause first:

1. **`telemetry.ex`** — skip the `tokens_consumed` counter when the measurement is absent, mirroring the guard already used for `tokens_remaining` three lines below.
2. **`telemetry.ex`** — guard `handle_cast({:increment, ...})` on a numeric amount and log instead of raising. Metrics collection should not be able to take the node down, whatever a future call site passes.
3. **`ets_owner.ex`** — create the subscription index tables in `EtsOwner`. They were previously created by whichever process called `init/0` first, which in tests can be an ephemeral ExUnit process; a named ETS table dies with its owner. Binding them to the long-lived owner removes that hazard. (`CharacterIndex.table_name/0` and `SystemIndex.table_name/0` added as accessors.)
4. **`test_helpers.ex`, two test files** — stop starting replacement `TaskSupervisor` / `SimpleSubscriptionManager` processes under the ExUnit supervisor. That hands a globally-registered name to a supervisor that tears it down at the end of the current test, stranding the rest of the run — and it silently masked the crash above. They now wait for the application supervisor instead.
5. **`test_helpers.ex`** — fix `wait_for_process/2`, which could never succeed. `Stream.take_while` drops the element whose predicate returns `false`, so the `{:ok, pid}` case was discarded and every call returned `{:error, :timeout}`.

## Verification

- Full suite green on seeds `359870`, `663349`, `1`, `42`, `7`, `20260805`.
- `MIX_ENV=test mix test.coverage.ci` green (382 tests, 0 failures).
- `mix format --check-formatted` clean; `mix credo --strict` adds no findings in the touched files; no `:boundary` warnings from the new `Core -> Subs` reference.
- Seed `359870` reproduces the failure on the parent commit (`71e4553`) and passes here.
- The two new tests in `telemetry_metrics_test.exs` fail without the handler fix and pass with it.

Run on Elixir 1.17.3 / OTP 26 locally, which is what was available — CI covers the pinned 1.19.5 / OTP 28.
